### PR TITLE
Ensure mock status code callback return value is non-empty

### DIFF
--- a/src/Mock/OpenApiDataMockerRouteMiddleware.php
+++ b/src/Mock/OpenApiDataMockerRouteMiddleware.php
@@ -87,7 +87,7 @@ final class OpenApiDataMockerRouteMiddleware implements MiddlewareInterface
         $customCallback = $this->getMockStatusCodeCallback;
         $customAfterCallback = $this->afterCallback;
         $mockedStatusCode = (is_callable($customCallback)) ? $customCallback($request, $this->responses) : null;
-        if (array_key_exists($mockedStatusCode, $this->responses)) {
+        if ($mockedStatusCode && array_key_exists($mockedStatusCode, $this->responses)) {
             // response schema successfully selected, we can mock it now
             $statusCode = ($mockedStatusCode === 'default') ? 200 : (int) $mockedStatusCode;
             $mockedResponse = (array) $this->responses[$mockedStatusCode];


### PR DESCRIPTION
Fixes #1 

Prevents a PHP 7.4 warning:
```
array_key_exists(): The first argument should be either a string or an integer in openapi-data-mocker-server-middleware\src\Mock\OpenApiDataMockerRouteMiddleware.php on line 90
```
when customCallback returns an empty value.